### PR TITLE
Add Modes to Translatable Strings

### DIFF
--- a/src/renderers.js
+++ b/src/renderers.js
@@ -8,11 +8,7 @@ function commands (el, id) {
 }
 
 function modes (el, id) {
-  var texts = {
-    markdown: 'm\u2193',
-    wysiwyg: 'wysiwyg'
-  };
-  setText(el, texts[id] || id);
+  setText(el, strings.modes[id] || id);
 }
 
 module.exports = {

--- a/src/strings.js
+++ b/src/strings.js
@@ -63,5 +63,9 @@ module.exports = {
     upload: ', or upload a file',
     uploading: 'Uploading your file...',
     uploadfailed: 'The upload failed! That\'s all we know.'
-  }
+  },
+  modes: {
+    wysiwyg: 'wysiwyg',
+    markdown: 'm\u2193',
+  },
 };


### PR DESCRIPTION
Buttons were translatable but modes were not. This resolves this issue so both string sets can be changed in the same manner.