### PR TITLE
Add CSS File to Bower `main`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,10 @@
   "name": "woofmark",
   "version": "4.2.3",
   "description": "Barking up the DOM tree. A modular, progressive, and beautiful Markdown and HTML editor",
-  "main": "dist/woofmark.js",
+  "main": [
+    "dist/woofmark.js",
+    "dist/woofmark.css",
+  ],
   "homepage": "https://github.com/bevacqua/woofmark",
   "authors": [
     "Nicolas Bevacqua <nicolasbevacqua@gmail.com>"


### PR DESCRIPTION
Automated build tools like [wiredep](https://www.npmjs.com/package/wiredep) work better when CSS files are included as part of the `main` configuration in the bower.json file. The bower.json spec also indicates that styles should be included if they should be used in conjunction with the file.