### PR TITLE
Escape HTML characters properly in WYSIWYG editing

### DIFF
--- a/src/getSurface.js
+++ b/src/getSurface.js
@@ -209,7 +209,13 @@ function surface (textarea, editable, droparea) {
   }
 
   function readNode (el) {
-    return el.nodeType === 3 ? fixEOL(el.textContent || el.innerText || '') : '';
+    if(el.nodeType === 3) {
+      // Using browser escaping to clean up any special characters
+      var toText = doc.createElement('div');
+      toText.appendChild(el.cloneNode());
+      return toText.innerHTML || '';
+    }
+    return '';
   }
 }
 


### PR DESCRIPTION
Fixes the issue bevacqua/woofmark#47

This was a slightly bigger issue than the original bug indicated. If any content was able to be injected into these fields that was not properly escaped, it could be used to execute code. Sanitation should be on the server, it should be Markdown on entering, and if there is arbitrary code execution happening on the site then there are likely bigger issues. Still, no need to keep it around, especially when it's causing other issues.

To handle the original issue we converted the text itself to it's escaped form in chunks so we could continue to use the chunk properties as expected.

With that change, the selection indexes that were based on the browser were wrong. Browsers handle text and selections based on the unescaped text (e.g. a cursor at the end of this string "<3" is at index 2). So we needed to get the difference by escaping all of the characters between the start of a string and selection point so we could offset the `anchorOffset` and `focusOffset` properly. We then need to reverse that conversion when "reselecting".

Note that this only applies to WYSIWYG changes. Changes made through the `<textarea>` are handled fine with regards to this issue.