### PR TITLE
Dynamic Mode Registration + Change Events & Stashing

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -59,6 +59,7 @@ function Editor (textarea, options) {
 
   this.components = {
     textarea: textarea,
+    parent: textarea.parentNode,
     droparea: tag({ c: 'wk-container-drop' }),
     switchboard: tag({ c: 'wk-switchboard' }),
     commands: tag({ c: 'wk-commands' }),
@@ -217,7 +218,33 @@ Editor.prototype.destroy = function () {
     this.textarea.value = this.getMarkdown();
   }
   classes.rm(this.textarea, 'wk-hide');
-  // bindEvents(true); // TODO
+
+  this.shortcuts.clear();
+
+  var parent = this.components.parent;
+  classes.rm(parent, 'wk-container');
+
+  // Remove components
+  parent.removeChild(this.components.commands);
+  if (this.placeholder) { parent.removeChild(this.placeholder); }
+  parent.removeChild(this.components.switchboard);
+
+  // Remove all modes that aren't using the textarea
+  var modes = Object.keys(this.modes);
+  var self = this;
+  modes.forEach(function (mode) {
+    if(self.modes[mode].element !== self.textarea) {
+      parent.removeChild(self.modes[mode].element);
+    }
+    // TODO Detach change event listeners for surface elements
+    this.shortcuts.detach(self.modes[mode].element);
+  });
+
+  // TODO
+  // if (this.options.images || this.options.attachments) {
+    // parent.removeChild(this.components.droparea);
+    // uploads(parent, this.components.droparea, this, o, remove);
+  // }
 };
 
 Editor.prototype.value = function getOrSetValue (input) {

--- a/src/events.js
+++ b/src/events.js
@@ -1,0 +1,70 @@
+'use strict';
+
+// Event Object
+function Evt(name, details) {
+  this.name = name;
+  this.details = details;
+  this.executionStopped = false;
+}
+Evt.prototype.stopPropagation = Evt.prototype.stopExecution = function () {
+  this.executionStopped = true;
+};
+
+// Extension Functionality
+function on (event, callback) {
+  this._events = this._events || {};
+  if(!this._events[event]) {
+    this._events[event] = [];
+  }
+
+  this._events[event].push(callback);
+}
+
+function off (event, callback) {
+  this._events = this._events || {};
+  if(!this._events[event]) {
+    return false;
+  }
+
+  if(arguments.length === 1) {
+    delete this._events[event];
+  } else {
+    var idx = this._events[event].indexOf(callback);
+
+    if(idx < 0) { return false; }
+    this._events[event].splice(idx, 1);
+
+    if(!this._events[event].length) {
+      delete this._events[event];
+    }
+  }
+
+  return true;
+}
+
+function trigger (event) {
+  this._events = this._events || {};
+  if(!this._events[event]) {
+    return;
+  }
+
+  var evt = new Evt(event, Array.prototype.slice.call(arguments, 1));
+  var args = Array.prototype.slice.call(arguments, 1);
+  args.unshift(evt);
+  for(var h = 0; h < this._events[event].length; h++) {
+    this._events[event][h].apply(this, args);
+    if(evt.executionStopped) {
+      break;
+    }
+  }
+
+  return evt;
+}
+
+module.exports = {
+  extend: function (obj) {
+    obj.prototype.on = on.bind(obj);
+    obj.prototype.off = off.bind(obj);
+    obj.prototype.trigger = trigger.bind(obj);
+  },
+};

--- a/src/modes/markdown/textareaSurface.js
+++ b/src/modes/markdown/textareaSurface.js
@@ -3,8 +3,8 @@
 var Events = require('../../events');
 var utils = require('../../utils');
 
-function TextSurface (textarea) {
-  this.textarea = textarea;
+function TextSurface (editor) {
+  var textarea = this.textarea = editor.textarea;
 
   var self = this;
   var _cached = this.read();

--- a/src/modes/markdown/textareaSurface.js
+++ b/src/modes/markdown/textareaSurface.js
@@ -1,7 +1,29 @@
 'use strict';
 
+var Events = require('../../events');
+var utils = require('../../utils');
+
 function TextSurface (textarea) {
   this.textarea = textarea;
+
+  var self = this;
+  var _cached = this.read();
+  var debouncedChange = utils.debounce(sendChange, 100);
+
+  textarea.addEventListener('blur', sendChange);
+  textarea.addEventListener('cut', sendChange);
+  textarea.addEventListener('paste', sendChange);
+  textarea.addEventListener('change', debouncedChange);
+  textarea.addEventListener('input', debouncedChange);
+  textarea.addEventListener('keypress', debouncedChange);
+
+  function sendChange () {
+    var updated = self.read();
+    if(_cached !== updated) {
+      _cached = updated;
+      self.trigger('change', updated);
+    }
+  }
 }
 
 TextSurface.prototype.focus = function () {
@@ -31,5 +53,7 @@ TextSurface.prototype.readSelection = function (state) {
   state.start = this.textarea.selectionStart;
   state.end = this.textarea.selectionEnd;
 };
+
+Events.extend(TextSurface);
 
 module.exports = TextSurface;

--- a/src/modes/markdown/textareaSurface.js
+++ b/src/modes/markdown/textareaSurface.js
@@ -54,6 +54,17 @@ TextSurface.prototype.readSelection = function (state) {
   state.end = this.textarea.selectionEnd;
 };
 
+TextSurface.prototype.toMarkdown = function () {
+  return this.read();
+};
+
+TextSurface.prototype.writeMarkdown = function (markdown) {
+  return this.write((markdown || '').trim());
+};
+
+TextSurface.prototype.toHTML = function () {
+  return this.editor.parseMarkdown(this.read());
+};
 Events.extend(TextSurface);
 
 module.exports = TextSurface;

--- a/src/modes/wysiwyg/wysiwygSurface.js
+++ b/src/modes/wysiwyg/wysiwygSurface.js
@@ -6,8 +6,10 @@ var utils = require('../../utils');
 var doc = global.document;
 var ropen = /^(<[^>]+(?: [^>]*)?>)/;
 var rclose = /(<\/[^>]+>)$/;
+var rparagraph = /^<p><\/p>\n?$/i;
 
 function WysiwygSurface (editor, options) {
+  this.editor = editor;
   var editable = this.editable = doc.createElement('div');
   editable.className = ['wk-wysiwyg', 'wk-hide'].concat(options.classes).join(' ');
   editable.contentEditable = true;
@@ -112,6 +114,21 @@ WysiwygSurface.prototype.readSelection = function (state) {
       context.end = context.text.length + escapeNodeText(elText.substring(0, sel.focusOffset)).length;
     }
   }
+};
+
+WysiwygSurface.prototype.toMarkdown = function () {
+  return this.editor.parseHTML(this.read());
+};
+
+WysiwygSurface.prototype.writeMarkdown = function (markdown) {
+  var html = this.editor.parseMarkdown(markdown || '')
+    .replace(rparagraph, '') // Remove empty <p> tags
+    .trim();
+  return this.write(html);
+};
+
+WysiwygSurface.prototype.toHTML = function () {
+  return this.read();
 };
 
 function walk (el, peek, ctx, siblings) {

--- a/src/modes/wysiwyg/wysiwygSurface.js
+++ b/src/modes/wysiwyg/wysiwygSurface.js
@@ -7,8 +7,10 @@ var doc = global.document;
 var ropen = /^(<[^>]+(?: [^>]*)?>)/;
 var rclose = /(<\/[^>]+>)$/;
 
-function WysiwygSurface (editable) {
-  this.editable = editable;
+function WysiwygSurface (editor, options) {
+  var editable = this.editable = doc.createElement('div');
+  editable.className = ['wk-wysiwyg', 'wk-hide'].concat(options.classes).join(' ');
+  editable.contentEditable = true;
 
   var self = this;
   var _cached = this.read();

--- a/src/modes/wysiwyg/wysiwygSurface.js
+++ b/src/modes/wysiwyg/wysiwygSurface.js
@@ -1,11 +1,34 @@
 'use strict';
 
+var Events = require('../../events');
+var utils = require('../../utils');
+
 var doc = global.document;
 var ropen = /^(<[^>]+(?: [^>]*)?>)/;
 var rclose = /(<\/[^>]+>)$/;
 
 function WysiwygSurface (editable) {
   this.editable = editable;
+
+  var self = this;
+  var _cached = this.read();
+  var debouncedChange = utils.debounce(sendChange, 200);
+
+  editable.addEventListener('blur', sendChange);
+  editable.addEventListener('cut', sendChange);
+  editable.addEventListener('paste', sendChange);
+  editable.addEventListener('textinput', debouncedChange);
+  editable.addEventListener('input', debouncedChange);
+  editable.addEventListener('keypress', debouncedChange);
+  editable.addEventListener('keyup', debouncedChange);
+
+  function sendChange () {
+    var updated = self.read();
+    if(_cached !== updated) {
+      _cached = updated;
+      self.trigger('change', updated);
+    }
+  }
 }
 
 WysiwygSurface.prototype.focus = function (forceImmediate) {
@@ -153,5 +176,7 @@ function unescapeText (el) {
   toText.textContent = el;
   return toText.textContent;
 }
+
+Events.extend(WysiwygSurface);
 
 module.exports = WysiwygSurface;

--- a/src/utils.js
+++ b/src/utils.js
@@ -115,6 +115,11 @@ exports.dispatchCustomEvent = function (element, event, params) {
   element.dispatchEvent(ev);
 };
 
+exports.dispatchBrowserEvent = function (element, event) {
+  var ev = new Event(event);
+  element.dispatchEvent(ev);
+};
+
 exports.dispatchClickEvent = function (element) {
   var ev = new MouseEvent('click');
   element.dispatchEvent(ev);

--- a/src/utils.js
+++ b/src/utils.js
@@ -119,3 +119,17 @@ exports.dispatchClickEvent = function (element) {
   var ev = new MouseEvent('click');
   element.dispatchEvent(ev);
 };
+
+exports.debounce = function (cb, ms) {
+  var tmr;
+  return function () {
+    var self = this,
+      args = Array.prototype.slice.call(arguments);
+
+    clearTimeout(tmr);
+    tmr = setTimeout(function () {
+      tmr = undefined;
+      cb.apply(self, args);
+    }, ms);
+  };
+};


### PR DESCRIPTION
Modes can now be dynamically registered with barkmark. In theory this allows support for third party integrations of different modes. In practice, this is non-obvious and likely still buggy. This is a potential future feature but is not officially going to be a part of the API for things yet. Not until we can assure this is functional in the way we want.

The other major change here that comes coupled with the above is change events. Surfaces now individually fire change events as the user makes modifications, and that change is then stored back into the `textarea` element. That means that the textarea should always be in a "submittable" state and that other systems like angular or react could easily use this as an editor on data models.

Note that change events are debounced to 100ms so if the user is constantly typing for a long period of time, it may be a bit before a change event is fired and the `textarea` is updated. This is done because the cost of doing HTML -> Markdown conversion is too high for every keystroke and would impact performance and a users ability to insert text reasonably if we were trying to do that constantly.